### PR TITLE
fix: 减少不必要的实例化，提升滚动性能

### DIFF
--- a/src/helpers/date-helper.ts
+++ b/src/helpers/date-helper.ts
@@ -1,4 +1,6 @@
 import { ViewMode } from "../types/public-types";
+import DateTimeFormatOptions = Intl.DateTimeFormatOptions;
+import DateTimeFormat = Intl.DateTimeFormat;
 
 type DateHelperScales =
   | "year"
@@ -8,6 +10,17 @@ type DateHelperScales =
   | "minute"
   | "second"
   | "millisecond";
+
+const intlDTCache = {};
+const getCachedDateTimeFormat = (locString: string | string[], opts: DateTimeFormatOptions = {}): DateTimeFormat => {
+  const key = JSON.stringify([locString, opts]);
+  let dtf = intlDTCache[key];
+  if (!dtf) {
+    dtf = new Intl.DateTimeFormat(locString, opts);
+    intlDTCache[key] = dtf;
+  }
+  return dtf;
+};
 
 export const addToDate = (
   date: Date,
@@ -134,7 +147,7 @@ export const seedDates = (
 };
 
 export const getLocaleMonth = (date: Date, locale: string) => {
-  let bottomValue = new Intl.DateTimeFormat(locale, {
+  let bottomValue = getCachedDateTimeFormat(locale, {
     month: "long",
   }).format(date);
   bottomValue = bottomValue.replace(


### PR DESCRIPTION
## 起因


今天打开甘特图组件，发现本地渲染拖动掉帧严重。
​

使用Chrome Devtools分析，发现有许多的long tasks
![image.png](https://cdn.nlark.com/yuque/0/2021/png/566082/1628834513784-2c81fa1a-4ae7-4778-9d41-3cd4b82ad1ea.png#clientId=u85854196-5e81-4&from=paste&height=420&id=u36f16e2d&margin=%5Bobject%20Object%5D&name=image.png&originHeight=840&originWidth=2510&originalType=binary&ratio=1&size=435370&status=done&style=none&taskId=u5d4b8e07-1c5b-4bb5-af60-7a7d4efa14e&width=1255)
![image.png](https://cdn.nlark.com/yuque/0/2021/png/566082/1628834736362-961bad0d-2dcf-4ca5-a144-c564d0592e81.png#clientId=u85854196-5e81-4&from=paste&height=170&id=u4a91f5d8&margin=%5Bobject%20Object%5D&name=image.png&originHeight=340&originWidth=2296&originalType=binary&ratio=1&size=81753&status=done&style=none&taskId=u5e41e0c8-0413-4e30-8efb-d5e81700d9f&width=1148)
继续分析，发现单任务中，`new Intl.DateTimeFormat` 方法占用时间比较长。
​

找到相关的issue：[https://github.com/moment/luxon/issues/352](https://github.com/moment/luxon/issues/352)。**主要原因是 Intl.DateTimeFormat 每次 toLocaleString 调用都会new一个实例化，成本相对较高，导致非美国语言环境的性能下降了 1000 倍**
![image.png](https://cdn.nlark.com/yuque/0/2021/png/566082/1628834723580-69dfd13f-62ad-4a08-980f-cf5db81d9ff7.png#clientId=u85854196-5e81-4&from=paste&height=131&id=uc2229348&margin=%5Bobject%20Object%5D&name=image.png&originHeight=262&originWidth=894&originalType=binary&ratio=1&size=40932&status=done&style=none&taskId=u38948722-bd70-4bf2-bdc7-3a74d7f63dd&width=447)


## 解决方案


参考 [https://github.com/moment/luxon/commit/bb77d5e6b968b0a2cc1be72d295f40a43a6687fb](https://github.com/moment/luxon/commit/bb77d5e6b968b0a2cc1be72d295f40a43a6687fb)，给 **Intl.DateTimeFormat** 方法增加缓存，避免不必要的实例化
​

## 效果

在本地验证后，发现10秒内long task数减少了一半。
![image.png](https://cdn.nlark.com/yuque/0/2021/png/566082/1628835016068-bcc2778e-ad34-4aa4-aa67-1a38a8d92102.png#clientId=u85854196-5e81-4&from=paste&height=296&id=ub4f15d98&margin=%5Bobject%20Object%5D&name=image.png&originHeight=592&originWidth=2484&originalType=binary&ratio=1&size=252876&status=done&style=none&taskId=u3fbcd82c-ce86-4749-9089-5676215ba04&width=1242)

fps数也有所提升

优化前，最低只有16fps，最高只有19fps
https://gitee.notion.site/3ecd5739d85546a6a48042bb77a554c8