### PR TITLE
fix: [proxima-1341、proxima-13412] 甘特图视图，折叠事项时页面崩溃&连接线弹框，显示两个结束时间

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxima-gantt",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.modern.js",

--- a/src/components/gantt/gantt.tsx
+++ b/src/components/gantt/gantt.tsx
@@ -148,7 +148,7 @@ export const Gantt: React.FunctionComponent<GanttProps> = ({
   const [ganttEvent, setGanttEvent] = useState<GanttEvent>({
     action: "",
   });
-  const [currentConnection, setCurrentConnection] = useState(null);
+  const [currentConnection, setCurrentConnection] = useState<any>(null);
   const [selectedTask, setSelectedTask] = useState<BarTask>();
   const [failedTask, setFailedTask] = useState<BarTask | null>(null);
 
@@ -853,6 +853,21 @@ export const Gantt: React.FunctionComponent<GanttProps> = ({
     },
     [renderOverflowTooltip]
   );
+  // 打开了连线弹窗后，如果事项折叠后需要关闭弹窗
+  const hideDeleteTooltip = useMemo(() => {
+    if (currentConnection) {
+      const source = tasks.find(
+        task => task.id === currentConnection.connection?.sourceId
+      );
+      const target = tasks.find(
+        task => task.id === currentConnection.connection?.targetId
+      );
+      if (!(source && target)) {
+        return true;
+      }
+    }
+    return false;
+  }, [currentConnection, tasks]);
   return (
     <div className={styles.box}>
       <I18n lngDict={langBundle} locale={locale}>
@@ -1002,7 +1017,7 @@ export const Gantt: React.FunctionComponent<GanttProps> = ({
                   workFlowStatusColor={workFlowStatusColor}
                 />
               )}
-              {currentConnection && (
+              {currentConnection && !hideDeleteTooltip && (
                 <DeleteTooltip
                   tasks={tasks}
                   taskListWidth={taskListWidth}

--- a/src/components/other/deleteTooltip.tsx
+++ b/src/components/other/deleteTooltip.tsx
@@ -135,7 +135,7 @@ export const DeleteTooltip: React.FC<TooltipProps> = memo(
                 <span>{targetTask[0]?.name}</span>
               </div>
               <div className={styles.date}>
-                {currentConnection.connection?.endpoints[1]?.anchor
+                {currentConnection.connection?.endpoints?.[1]?.anchor
                   ?.cssClass === "Right"
                   ? `${t("fields.endDate")}：${dayjs(targetTask[0]?.end).format(
                       dayFormat

--- a/src/components/other/deleteTooltip.tsx
+++ b/src/components/other/deleteTooltip.tsx
@@ -101,10 +101,10 @@ export const DeleteTooltip: React.FC<TooltipProps> = memo(
               <div className={styles.date}>
                 {currentConnection.connection?.endpoints?.[0].anchor
                   ?.cssClass === "Right"
-                  ? `${t("fields.startDate")}：${dayjs(
-                      sourceTask[0]?.end
-                    ).format(dayFormat)}`
-                  : `${t("fields.endDate")}：${dayjs(
+                  ? `${t("fields.endDate")}：${dayjs(sourceTask[0]?.end).format(
+                      dayFormat
+                    )}`
+                  : `${t("fields.startDate")}：${dayjs(
                       sourceTask[0]?.start
                     ).format(dayFormat)}`}
               </div>


### PR DESCRIPTION
![image](https://github.com/moriahq/gantt-task-react/assets/21971178/b8cf6fd0-cfb7-4560-acdc-58aafda5dc1b)
